### PR TITLE
Fix database status endpoint table listing

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -106,18 +106,17 @@ async function startServer() {
       try {
         // Test database connection
         await knex.raw('SELECT 1');
-        
-        // Get table info
-        const tables = await knex.raw("SELECT name FROM sqlite_master WHERE type='table'");
-        
-        // Get database file info
-        const dbStats = await knex.raw("PRAGMA database_list");
-        
+
+        // Get table info using Knex query builder for cross-driver compatibility
+        const tableRows = await knex('sqlite_master')
+          .select('name')
+          .where({ type: 'table' });
+
         return {
           success: true,
           status: 'connected',
           database: 'SQLite',
-          tables: tables.map(row => row.name),
+          tables: tableRows.map(row => row.name),
           connection: {
             type: 'sqlite3',
             file: './eDen.db'


### PR DESCRIPTION
## Summary
- fix listing of sqlite tables in the DB status route

## Testing
- `npm run check:syntax` *(fails: cannot find module `check-syntax.mjs`)*

------
https://chatgpt.com/codex/tasks/task_e_6857a56ee8448321847e0d67017b11e1