### PR TITLE
Remove extraneous parent comment

### DIFF
--- a/src/squirrel/squirrel.js
+++ b/src/squirrel/squirrel.js
@@ -191,7 +191,7 @@ const $ = (id, props = {}) => {
   element._ = element.style;
   
   // Parent (support des sélecteurs)
-  const parent = merged.parent || '#view';  // ← Votre changement
+  const parent = merged.parent || '#view';
   const appendToParent = () => {
     if (typeof parent === 'string') {
       const target = document.querySelector(parent);


### PR DESCRIPTION
## Summary
- clean up squirrel parent logic by removing a leftover comment

## Testing
- `npm run check:syntax` *(fails: Cannot find module 'check-syntax.mjs')*

------
https://chatgpt.com/codex/tasks/task_e_6857ab5c64d08321a55ebce17111312a