### PR TITLE
Add basic Vitest configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,10 @@
     "tauri:dev": "tauri dev",
     "debug-bundle": "node debug-bundle.mjs",
     "build:minimal": "rollup -c scripts_utils/rollup.config.minimal.js",
-    "check:syntax": "node check-syntax.mjs"
+    "check:syntax": "node check-syntax.mjs",
+    "test": "vitest",
+    "test:run": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^28.0.6",
@@ -71,7 +74,10 @@
     "rollup": "^4.44.0",
     "rollup-plugin-filesize": "^10.0.0",
     "terser": "^5.43.1",
-    "ws": "^8.18.2"
+    "ws": "^8.18.2",
+    "vitest": "^1.6.0",
+    "jsdom": "^24.0.0",
+    "@testing-library/dom": "^9.3.1"
   },
   "dependencies": {
     "@codemirror/lang-javascript": "^6.2.4",

--- a/test/button.test.js
+++ b/test/button.test.js
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { Button } from '../src/squirrel/components/button_builder.js';
+
+describe('Button Component', () => {
+  it('should create a button element', () => {
+    const button = Button({ text: 'Test' });
+    expect(button.tagName).toBe('BUTTON');
+    expect(button.textContent).toBe('Test');
+  });
+});

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,1 @@
+// Vitest setup file. Add global mocks here if needed.

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./test/setup.js'],
+  },
+});


### PR DESCRIPTION
## Summary
- add Vitest config and example button test
- wire up Vitest commands in package.json
- include minimal test setup file

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857ab601e7083219525acbf0a8da3ec